### PR TITLE
Method invocation call for Nil attribute

### DIFF
--- a/lib/thinking_sphinx/deltas/datetime_delta.rb
+++ b/lib/thinking_sphinx/deltas/datetime_delta.rb
@@ -105,7 +105,8 @@ class ThinkingSphinx::Deltas::DatetimeDelta < ThinkingSphinx::Deltas::DefaultDel
   # @return [Boolean] True if within the threshold window, otherwise false.
   # 
   def toggled(instance)
-    instance.send(@column) > @threshold.ago
+    res = instance.send(@column)
+    res && (res > @threshold.ago)
   end
   
   # Returns the SQL query that resets the model data after a normal index. For

--- a/spec/thinking_sphinx/deltas/datetime_delta_spec.rb
+++ b/spec/thinking_sphinx/deltas/datetime_delta_spec.rb
@@ -107,6 +107,13 @@ describe ThinkingSphinx::Deltas::DatetimeDelta do
       
       @datetime_delta.toggled(instance).should be_false
     end
+
+    it "should return false if the column value is null" do
+      instance = stub('instance', :updated_at => nil)
+      @datetime_delta.threshold = 20.minutes
+
+      @datetime_delta.toggled(instance).should be_false
+    end
   end
   
   describe '#reset_query' do


### PR DESCRIPTION
Hello,

 Here is a fix for the problem which arose on my production server when updated_at column was null (because it was just added by a migration). This resulted in exception when a record was updated, because 'index_delta' callback called 'toggled' method for nill column.

I've added the test, but I didn't run it - couldn't setup environment  with older rspec.

Thanks for attention,
KIR
