### PR TITLE
ENV Variable to disable the merge

### DIFF
--- a/lib/thinking_sphinx/deltas/datetime_delta.rb
+++ b/lib/thinking_sphinx/deltas/datetime_delta.rb
@@ -79,7 +79,7 @@ class ThinkingSphinx::Deltas::DatetimeDelta < ThinkingSphinx::Deltas::DefaultDel
     
     output = `#{config.bin_path}#{config.indexer_binary_name} --config #{config.config_file}#{rotate} #{model.delta_index_names.join(' ')}`
     
-    unless ENV['DISABLE_MERGE']
+    unless ENV['DISABLE_MERGE'] == 'true'
       model.sphinx_indexes.select(&:delta?).each do |index|
         output += `#{config.bin_path}#{config.indexer_binary_name} --config #{config.config_file}#{rotate} --merge #{index.core_name} #{index.delta_name} --merge-dst-range sphinx_deleted 0 0`
       end


### PR DESCRIPTION
Merges are not always the best strategy. The merge does so much more I/O that we cannot complete it fast enough to keep the delta index fresh. We then run the main index every 24 hours against a slave database.
