### PR TITLE
Don't delete delta options while reading them

### DIFF
--- a/lib/thinking_sphinx/deltas/datetime_delta.rb
+++ b/lib/thinking_sphinx/deltas/datetime_delta.rb
@@ -51,8 +51,8 @@ class ThinkingSphinx::Deltas::DatetimeDelta < ThinkingSphinx::Deltas::DefaultDel
     else # Thinking Sphinx v3
       @adapter  = arg
     end
-    @column     = options.delete(:column)    || :updated_at
-    @threshold  = options.delete(:threshold) || 1.day
+    @column     = options[:column]    || :updated_at
+    @threshold  = options[:threshold] || 1.day
   end
 
   # Does absolutely nothing, beyond returning true. Thinking Sphinx expects


### PR DESCRIPTION
ThinkingSphinx 3.1 seems to instantiate the delta processor twice when generating the sphinx configuration (e.g., during rake ts:rebuild).

This patch is required to have a custom threshold value properly used during configuration generation.
